### PR TITLE
Introduce API envelope and DTOs; enrich Company, Job, Review models and controllers

### DIFF
--- a/src/main/java/com/skywins/Job/Application/common/ApiResponse.java
+++ b/src/main/java/com/skywins/Job/Application/common/ApiResponse.java
@@ -1,0 +1,15 @@
+package com.skywins.Job.Application.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ApiResponse<T> {
+  private T data;
+  private MetaResponse meta;
+
+  public static <T> ApiResponse<T> of(T data, long totalItems) {
+    return new ApiResponse<>(data, new MetaResponse(totalItems));
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/common/MetaResponse.java
+++ b/src/main/java/com/skywins/Job/Application/common/MetaResponse.java
@@ -1,0 +1,10 @@
+package com.skywins.Job.Application.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MetaResponse {
+  private long totalItems;
+}

--- a/src/main/java/com/skywins/Job/Application/company/Company.java
+++ b/src/main/java/com/skywins/Job/Application/company/Company.java
@@ -26,6 +26,15 @@ public class Company implements Serializable {
   @Column(name = "company_description")
   private String description;
 
+  @Column(name = "logo_url")
+  private String logoUrl;
+
+  @Column(name = "industry")
+  private String industry;
+
+  @Column(name = "location")
+  private String location;
+
   @JsonIgnore
   @OneToMany(mappedBy = "company", fetch = FetchType.LAZY)
   private List<Job> jobs;

--- a/src/main/java/com/skywins/Job/Application/company/CompanyController.java
+++ b/src/main/java/com/skywins/Job/Application/company/CompanyController.java
@@ -1,5 +1,7 @@
 package com.skywins.Job.Application.company;
 
+import com.skywins.Job.Application.common.ApiResponse;
+import com.skywins.Job.Application.company.dto.CompanyResponse;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +17,19 @@ public class CompanyController {
   }
 
   @GetMapping
-  public ResponseEntity<List<Company>> getAllCompanies() {
-    return new ResponseEntity<>(companyService.getAllCompanies(), HttpStatus.OK);
+  public ResponseEntity<ApiResponse<List<CompanyResponse>>> getAllCompanies() {
+    List<CompanyResponse> companies =
+        companyService.getAllCompanies().stream().map(CompanyResponse::from).toList();
+    return new ResponseEntity<>(ApiResponse.of(companies, companies.size()), HttpStatus.OK);
   }
 
   @PutMapping("/{id}")
   public ResponseEntity<String> updateCompany(@PathVariable Long id, @RequestBody Company company) {
-    companyService.updateCompany(company, id);
-    return new ResponseEntity<>("Company Updated Sucessfully", HttpStatus.OK);
+    boolean updated = companyService.updateCompany(company, id);
+    if (updated) {
+      return new ResponseEntity<>("Company Updated Sucessfully", HttpStatus.OK);
+    }
+    return new ResponseEntity<>("Company Not Found", HttpStatus.NOT_FOUND);
   }
 
   @PostMapping()
@@ -42,10 +49,10 @@ public class CompanyController {
   }
 
   @GetMapping("/{id}")
-  public ResponseEntity<Company> getCompany(@PathVariable Long id) {
+  public ResponseEntity<CompanyResponse> getCompany(@PathVariable Long id) {
     Company company = companyService.getCompanyById(id);
     if (company != null) {
-      return new ResponseEntity<>(company, HttpStatus.OK);
+      return new ResponseEntity<>(CompanyResponse.from(company), HttpStatus.OK);
     } else {
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }

--- a/src/main/java/com/skywins/Job/Application/company/dto/CompanyResponse.java
+++ b/src/main/java/com/skywins/Job/Application/company/dto/CompanyResponse.java
@@ -1,0 +1,50 @@
+package com.skywins.Job.Application.company.dto;
+
+import com.skywins.Job.Application.company.Company;
+import com.skywins.Job.Application.job.Job;
+import com.skywins.Job.Application.review.Review;
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CompanyResponse {
+  private Long id;
+  private String name;
+  private String description;
+  private String logoUrl;
+  private String industry;
+  private String location;
+  private String initial;
+  private double rating;
+  private int reviewCount;
+  private int openJobCount;
+
+  public static CompanyResponse from(Company company) {
+    List<Review> reviews =
+        company.getReviews() == null ? Collections.emptyList() : company.getReviews();
+    List<Job> jobs = company.getJobs() == null ? Collections.emptyList() : company.getJobs();
+    double averageRating = reviews.stream().mapToDouble(Review::getRating).average().orElse(0.0);
+
+    return new CompanyResponse(
+        company.getId(),
+        company.getName(),
+        company.getDescription(),
+        company.getLogoUrl(),
+        company.getIndustry(),
+        company.getLocation(),
+        buildInitial(company.getName()),
+        Math.round(averageRating * 10.0) / 10.0,
+        reviews.size(),
+        jobs.size());
+  }
+
+  private static String buildInitial(String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    return name.trim().substring(0, 1).toUpperCase();
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/company/dto/CompanySummaryResponse.java
+++ b/src/main/java/com/skywins/Job/Application/company/dto/CompanySummaryResponse.java
@@ -1,0 +1,29 @@
+package com.skywins.Job.Application.company.dto;
+
+import com.skywins.Job.Application.company.Company;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CompanySummaryResponse {
+  private Long id;
+  private String name;
+  private String logoUrl;
+  private String initial;
+
+  public static CompanySummaryResponse from(Company company) {
+    if (company == null) {
+      return null;
+    }
+    return new CompanySummaryResponse(
+        company.getId(), company.getName(), company.getLogoUrl(), buildInitial(company.getName()));
+  }
+
+  private static String buildInitial(String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    return name.trim().substring(0, 1).toUpperCase();
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/company/impl/CompanyServiceimpl.java
+++ b/src/main/java/com/skywins/Job/Application/company/impl/CompanyServiceimpl.java
@@ -28,6 +28,9 @@ public class CompanyServiceimpl implements CompanyService {
       companyToUpdate.setDescription((company.getDescription()));
       companyToUpdate.setName(company.getName());
       companyToUpdate.setJobs(company.getJobs());
+      companyToUpdate.setLogoUrl(company.getLogoUrl());
+      companyToUpdate.setIndustry(company.getIndustry());
+      companyToUpdate.setLocation(company.getLocation());
       companyRepository.save(companyToUpdate);
       return true;
     }

--- a/src/main/java/com/skywins/Job/Application/job/Job.java
+++ b/src/main/java/com/skywins/Job/Application/job/Job.java
@@ -3,6 +3,8 @@ package com.skywins.Job.Application.job;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.skywins.Job.Application.company.Company;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.*;
 
 @Entity
@@ -33,6 +35,33 @@ public class Job {
 
   @Column(name = "location")
   private String location;
+
+  @Column(name = "job_type")
+  private String jobType;
+
+  @Column(name = "employment_type")
+  private String employmentType;
+
+  @Column(name = "min_experience")
+  private Integer minExperience;
+
+  @Column(name = "max_experience")
+  private Integer maxExperience;
+
+  @ElementCollection
+  @CollectionTable(name = "job_skills", joinColumns = @JoinColumn(name = "job_id"))
+  @Column(name = "skill")
+  private List<String> skills;
+
+  @Column(name = "posted_at")
+  private LocalDateTime postedAt;
+
+  @PrePersist
+  public void prePersist() {
+    if (postedAt == null) {
+      postedAt = LocalDateTime.now();
+    }
+  }
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "company")

--- a/src/main/java/com/skywins/Job/Application/job/JobController.java
+++ b/src/main/java/com/skywins/Job/Application/job/JobController.java
@@ -1,5 +1,7 @@
 package com.skywins.Job.Application.job;
 
+import com.skywins.Job.Application.common.ApiResponse;
+import com.skywins.Job.Application.job.dto.JobResponse;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,9 +17,9 @@ public class JobController {
   }
 
   @GetMapping("/jobs")
-  public ResponseEntity<List<Job>> findAll() {
-
-    return ResponseEntity.ok(jobService.findAll());
+  public ResponseEntity<ApiResponse<List<JobResponse>>> findAll() {
+    List<JobResponse> jobs = jobService.findAll().stream().map(JobResponse::from).toList();
+    return ResponseEntity.ok(ApiResponse.of(jobs, jobs.size()));
   }
 
   @PostMapping("/jobs")
@@ -28,11 +30,11 @@ public class JobController {
   }
 
   @GetMapping("/jobs/{id}")
-  public ResponseEntity<Job> getJobById(@PathVariable Long id) {
+  public ResponseEntity<JobResponse> getJobById(@PathVariable Long id) {
     Job job = jobService.getJobById(id);
 
-    if (job != null) return new ResponseEntity<>(job, HttpStatus.OK);
-    return new ResponseEntity(HttpStatus.NOT_FOUND);
+    if (job != null) return new ResponseEntity<>(JobResponse.from(job), HttpStatus.OK);
+    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
   }
 
   @DeleteMapping("/jobs/{id}")

--- a/src/main/java/com/skywins/Job/Application/job/dto/ExperienceResponse.java
+++ b/src/main/java/com/skywins/Job/Application/job/dto/ExperienceResponse.java
@@ -1,0 +1,31 @@
+package com.skywins.Job.Application.job.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ExperienceResponse {
+  private Integer minYears;
+  private Integer maxYears;
+  private String label;
+
+  public static ExperienceResponse from(Integer minYears, Integer maxYears) {
+    return new ExperienceResponse(minYears, maxYears, buildLabel(minYears, maxYears));
+  }
+
+  private static String buildLabel(Integer minYears, Integer maxYears) {
+    if (minYears == null && maxYears == null) {
+      return null;
+    }
+    if (minYears != null && maxYears != null) {
+      return minYears.equals(maxYears)
+          ? minYears + " Years"
+          : minYears + " - " + maxYears + " Years";
+    }
+    if (minYears != null) {
+      return minYears + "+ Years";
+    }
+    return "Up to " + maxYears + " Years";
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/job/dto/JobResponse.java
+++ b/src/main/java/com/skywins/Job/Application/job/dto/JobResponse.java
@@ -1,0 +1,59 @@
+package com.skywins.Job.Application.job.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.skywins.Job.Application.company.dto.CompanySummaryResponse;
+import com.skywins.Job.Application.job.Job;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JobResponse {
+  private Long id;
+  private String title;
+  private String description;
+  private String minSalary;
+  private String maxSalary;
+  private String location;
+  private String jobType;
+  private String employmentType;
+  private ExperienceResponse experience;
+  private List<String> skills;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+  private LocalDateTime postedAt;
+
+  private boolean isNew;
+  private SalaryResponse salary;
+  private CompanySummaryResponse company;
+
+  public static JobResponse from(Job job) {
+    return new JobResponse(
+        job.getId(),
+        job.getTitle(),
+        job.getDescription(),
+        job.getMinSalary(),
+        job.getMaxSalary(),
+        job.getLocation(),
+        job.getJobType(),
+        job.getEmploymentType(),
+        ExperienceResponse.from(job.getMinExperience(), job.getMaxExperience()),
+        job.getSkills() == null ? Collections.emptyList() : job.getSkills(),
+        job.getPostedAt(),
+        isNew(job.getPostedAt()),
+        SalaryResponse.from(job.getMinSalary(), job.getMaxSalary()),
+        CompanySummaryResponse.from(job.getCompany()));
+  }
+
+  private static boolean isNew(LocalDateTime postedAt) {
+    if (postedAt == null) {
+      return false;
+    }
+    long ageInDays = ChronoUnit.DAYS.between(postedAt, LocalDateTime.now());
+    return ageInDays >= 0 && ageInDays <= 7;
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/job/dto/SalaryResponse.java
+++ b/src/main/java/com/skywins/Job/Application/job/dto/SalaryResponse.java
@@ -1,0 +1,43 @@
+package com.skywins.Job.Application.job.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SalaryResponse {
+  private String currency;
+  private Integer min;
+  private Integer max;
+  private String display;
+
+  public static SalaryResponse from(String minSalary, String maxSalary) {
+    Integer min = parseSalary(minSalary);
+    Integer max = parseSalary(maxSalary);
+    return new SalaryResponse("INR", min, max, buildDisplay(min, max));
+  }
+
+  private static Integer parseSalary(String salary) {
+    if (salary == null || salary.isBlank()) {
+      return null;
+    }
+    String numericSalary = salary.replaceAll("[^0-9]", "");
+    if (numericSalary.isBlank()) {
+      return null;
+    }
+    return Integer.valueOf(numericSalary);
+  }
+
+  private static String buildDisplay(Integer min, Integer max) {
+    if (min == null && max == null) {
+      return null;
+    }
+    if (min != null && max != null) {
+      return "₹" + min + " - ₹" + max;
+    }
+    if (min != null) {
+      return "₹" + min + "+";
+    }
+    return "Up to ₹" + max;
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/job/impl/JobServiceimpl.java
+++ b/src/main/java/com/skywins/Job/Application/job/impl/JobServiceimpl.java
@@ -55,6 +55,14 @@ public class JobServiceimpl implements JobService {
       job.setMinSalary(updatedJob.getMinSalary());
       job.setMaxSalary(updatedJob.getMaxSalary());
       job.setLocation(updatedJob.getLocation());
+      job.setJobType(updatedJob.getJobType());
+      job.setEmploymentType(updatedJob.getEmploymentType());
+      job.setMinExperience(updatedJob.getMinExperience());
+      job.setMaxExperience(updatedJob.getMaxExperience());
+      job.setSkills(updatedJob.getSkills());
+      if (updatedJob.getPostedAt() != null) {
+        job.setPostedAt(updatedJob.getPostedAt());
+      }
       jobRepository.save(job);
       return true;
     }

--- a/src/main/java/com/skywins/Job/Application/review/AllReviewsController.java
+++ b/src/main/java/com/skywins/Job/Application/review/AllReviewsController.java
@@ -1,0 +1,26 @@
+package com.skywins.Job.Application.review;
+
+import com.skywins.Job.Application.common.ApiResponse;
+import com.skywins.Job.Application.review.dto.ReviewResponse;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews")
+public class AllReviewsController {
+  private final ReviewService reviewService;
+
+  public AllReviewsController(ReviewService reviewService) {
+    this.reviewService = reviewService;
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<ReviewResponse>>> getAllReviews() {
+    List<ReviewResponse> reviews =
+        reviewService.getAllReviews().stream().map(ReviewResponse::from).toList();
+    return ResponseEntity.ok(ApiResponse.of(reviews, reviews.size()));
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/review/Review.java
+++ b/src/main/java/com/skywins/Job/Application/review/Review.java
@@ -3,6 +3,7 @@ package com.skywins.Job.Application.review;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.skywins.Job.Application.company.Company;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,6 +24,28 @@ public class Review {
 
   @Column(name = "rating")
   private double rating;
+
+  @Column(name = "pros")
+  private String pros;
+
+  @Column(name = "cons")
+  private String cons;
+
+  @Column(name = "reviewer_role")
+  private String reviewerRole;
+
+  @Column(name = "employment_status")
+  private String employmentStatus;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  public void prePersist() {
+    if (createdAt == null) {
+      createdAt = LocalDateTime.now();
+    }
+  }
 
   @JsonIgnore @ManyToOne private Company company;
 

--- a/src/main/java/com/skywins/Job/Application/review/ReviewController.java
+++ b/src/main/java/com/skywins/Job/Application/review/ReviewController.java
@@ -1,5 +1,7 @@
 package com.skywins.Job.Application.review;
 
+import com.skywins.Job.Application.common.ApiResponse;
+import com.skywins.Job.Application.review.dto.ReviewResponse;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,8 +17,11 @@ public class ReviewController {
   }
 
   @GetMapping("/reviews")
-  public ResponseEntity<List<Review>> getAllReview(@PathVariable Long companyId) {
-    return new ResponseEntity<>(reviewService.getAllReviews(companyId), HttpStatus.OK);
+  public ResponseEntity<ApiResponse<List<ReviewResponse>>> getAllReview(
+      @PathVariable Long companyId) {
+    List<ReviewResponse> reviews =
+        reviewService.getAllReviews(companyId).stream().map(ReviewResponse::from).toList();
+    return new ResponseEntity<>(ApiResponse.of(reviews, reviews.size()), HttpStatus.OK);
   }
 
   @PostMapping("/reviews")
@@ -32,9 +37,13 @@ public class ReviewController {
   }
 
   @GetMapping("/reviews/{reviewId}")
-  public ResponseEntity<Review> getReview(
+  public ResponseEntity<ReviewResponse> getReview(
       @PathVariable Long companyId, @PathVariable Long reviewId) {
-    return new ResponseEntity<>(reviewService.getReview(companyId, reviewId), HttpStatus.OK);
+    Review review = reviewService.getReview(companyId, reviewId);
+    if (review == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+    return new ResponseEntity<>(ReviewResponse.from(review), HttpStatus.OK);
   }
 
   @PutMapping("/reviews/{reviewId}")

--- a/src/main/java/com/skywins/Job/Application/review/ReviewService.java
+++ b/src/main/java/com/skywins/Job/Application/review/ReviewService.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 public interface ReviewService {
 
+  List<Review> getAllReviews();
+
   List<Review> getAllReviews(Long companyId);
 
   boolean addReview(Long companyId, Review review);

--- a/src/main/java/com/skywins/Job/Application/review/dto/ReviewResponse.java
+++ b/src/main/java/com/skywins/Job/Application/review/dto/ReviewResponse.java
@@ -1,0 +1,40 @@
+package com.skywins.Job.Application.review.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.skywins.Job.Application.company.dto.CompanySummaryResponse;
+import com.skywins.Job.Application.review.Review;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ReviewResponse {
+  private Long id;
+  private String title;
+  private String description;
+  private double rating;
+  private String pros;
+  private String cons;
+  private String reviewerRole;
+  private String employmentStatus;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+  private LocalDateTime createdAt;
+
+  private CompanySummaryResponse company;
+
+  public static ReviewResponse from(Review review) {
+    return new ReviewResponse(
+        review.getId(),
+        review.getTitle(),
+        review.getDescription(),
+        review.getRating(),
+        review.getPros(),
+        review.getCons(),
+        review.getReviewerRole(),
+        review.getEmploymentStatus(),
+        review.getCreatedAt(),
+        CompanySummaryResponse.from(review.getCompany()));
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/review/impl/ReviewServiceimpl.java
+++ b/src/main/java/com/skywins/Job/Application/review/impl/ReviewServiceimpl.java
@@ -19,6 +19,11 @@ public class ReviewServiceimpl implements ReviewService {
   }
 
   @Override
+  public List<Review> getAllReviews() {
+    return reviewRepository.findAll();
+  }
+
+  @Override
   public List<Review> getAllReviews(Long companyId) {
     List<Review> reviews = reviewRepository.findByCompanyId(companyId);
     return reviews;
@@ -47,28 +52,36 @@ public class ReviewServiceimpl implements ReviewService {
 
   @Override
   public boolean updateReview(Long companyId, Long reviewId, Review updatedReview) {
-    if (companyService.getCompanyById(companyId) != null) {
-      updatedReview.setCompany(companyService.getCompanyById(companyId));
-      updatedReview.setId(reviewId);
-      reviewRepository.save(updatedReview);
-      return true;
-    } else {
+    Review existingReview = getReview(companyId, reviewId);
+    if (existingReview == null) {
       return false;
     }
+    existingReview.setTitle(updatedReview.getTitle());
+    existingReview.setDescription(updatedReview.getDescription());
+    existingReview.setRating(updatedReview.getRating());
+    existingReview.setPros(updatedReview.getPros());
+    existingReview.setCons(updatedReview.getCons());
+    existingReview.setReviewerRole(updatedReview.getReviewerRole());
+    existingReview.setEmploymentStatus(updatedReview.getEmploymentStatus());
+    if (updatedReview.getCreatedAt() != null) {
+      existingReview.setCreatedAt(updatedReview.getCreatedAt());
+    }
+    reviewRepository.save(existingReview);
+    return true;
   }
 
   @Override
   public boolean deleteReview(Long companyId, Long reviewId) {
-    if (companyService.getCompanyById(companyId) != null && reviewRepository.existsById(reviewId)) {
-      Review review = reviewRepository.findById(reviewId).orElse(null);
-      Company company = review.getCompany();
-      company.getReviews().remove(review);
-      review.setCompany(null);
-      companyService.updateCompany(company, companyId);
-      reviewRepository.deleteById(reviewId);
-      return true;
-    } else {
+    Review review = getReview(companyId, reviewId);
+    if (review == null) {
       return false;
     }
+    Company company = review.getCompany();
+    if (company != null && company.getReviews() != null) {
+      company.getReviews().remove(review);
+    }
+    review.setCompany(null);
+    reviewRepository.deleteById(reviewId);
+    return true;
   }
 }


### PR DESCRIPTION
### Motivation

- Provide a consistent API response envelope with metadata and convert internal entities to tailored DTOs for client consumption.
- Enrich domain models with additional fields to support UI features such as logos, industries, skills, experience, salary formatting, and review details.

### Description

- Add `ApiResponse` and `MetaResponse` classes to wrap list responses with metadata (`totalItems`).
- Add DTOs `CompanyResponse`, `CompanySummaryResponse`, `JobResponse`, `ExperienceResponse`, `SalaryResponse`, and `ReviewResponse` and map entities to these DTOs in controllers.
- Extend `Company` with `logoUrl`, `industry`, and `location`, and update `CompanyServiceimpl` and `CompanyController` to handle these fields and return DTOs wrapped in `ApiResponse`.
- Extend `Job` with `jobType`, `employmentType`, `minExperience`, `maxExperience`, `skills`, and `postedAt` (with `@PrePersist`), update `JobServiceimpl` to persist and update these fields, and return `JobResponse` DTOs wrapped in `ApiResponse`.
- Extend `Review` with `pros`, `cons`, `reviewerRole`, `employmentStatus`, and `createdAt` (with `@PrePersist`), add `AllReviewsController` to expose all reviews, and update `ReviewServiceimpl` and `ReviewController` to use `ReviewResponse` DTOs and improved update/delete logic.

### Testing

- No new automated tests were added in this change set.
- Ran the existing test suite with `./mvnw test`, and the current project tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2415a78224832a90f6617f4595188b)