### PR TITLE
Add SavedJob feature: entity, repository, service, controller, and DTOs

### DIFF
--- a/src/main/java/com/skywins/Job/Application/savedjob/SavedJob.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/SavedJob.java
@@ -1,0 +1,49 @@
+package com.skywins.Job.Application.savedjob;
+
+import com.skywins.Job.Application.job.Job;
+import com.skywins.Job.Application.user.User;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(
+    name = "saved_jobs",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "job_id"}))
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"user", "job"})
+@EqualsAndHashCode(exclude = {"user", "job"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SavedJob {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "job_id", nullable = false)
+  private Job job;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  public void prePersist() {
+    if (createdAt == null) {
+      createdAt = LocalDateTime.now();
+    }
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/savedjob/SavedJobController.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/SavedJobController.java
@@ -1,0 +1,60 @@
+package com.skywins.Job.Application.savedjob;
+
+import com.skywins.Job.Application.common.ApiResponse;
+import com.skywins.Job.Application.savedjob.dto.SavedJobResponse;
+import com.skywins.Job.Application.savedjob.dto.SavedJobStatusResponse;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api")
+public class SavedJobController {
+  private final SavedJobService savedJobService;
+
+  public SavedJobController(SavedJobService savedJobService) {
+    this.savedJobService = savedJobService;
+  }
+
+  @GetMapping("/saved-jobs")
+  public ResponseEntity<ApiResponse<List<SavedJobResponse>>> findSavedJobs(
+      HttpServletRequest request) {
+    Long userId = getUserId(request);
+    List<SavedJobResponse> savedJobs =
+        savedJobService.findSavedJobsByUser(userId).stream().map(SavedJobResponse::from).toList();
+    return ResponseEntity.ok(ApiResponse.of(savedJobs, savedJobs.size()));
+  }
+
+  @GetMapping("/saved-jobs/ids")
+  public ResponseEntity<ApiResponse<List<Long>>> findSavedJobIds(HttpServletRequest request) {
+    Long userId = getUserId(request);
+    List<Long> savedJobIds = savedJobService.findSavedJobIdsByUser(userId);
+    return ResponseEntity.ok(ApiResponse.of(savedJobIds, savedJobIds.size()));
+  }
+
+  @PostMapping("/saved-jobs/{jobId}")
+  public ResponseEntity<?> saveJob(@PathVariable Long jobId, HttpServletRequest request) {
+    try {
+      Long userId = getUserId(request);
+      boolean saved = savedJobService.saveJob(userId, jobId);
+      return ResponseEntity.ok(ApiResponse.of(new SavedJobStatusResponse(jobId, saved), 1));
+    } catch (EntityNotFoundException ex) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+  }
+
+  @DeleteMapping("/saved-jobs/{jobId}")
+  public ResponseEntity<ApiResponse<SavedJobStatusResponse>> deleteSavedJob(
+      @PathVariable Long jobId, HttpServletRequest request) {
+    Long userId = getUserId(request);
+    boolean saved = savedJobService.deleteSavedJob(userId, jobId);
+    return ResponseEntity.ok(ApiResponse.of(new SavedJobStatusResponse(jobId, saved), 1));
+  }
+
+  private Long getUserId(HttpServletRequest request) {
+    return (Long) request.getAttribute("userId");
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/savedjob/SavedJobRepository.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/SavedJobRepository.java
@@ -1,0 +1,20 @@
+package com.skywins.Job.Application.savedjob;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SavedJobRepository extends JpaRepository<SavedJob, Long> {
+  List<SavedJob> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+  @Query("select savedJob.job.id from SavedJob savedJob where savedJob.user.id = :userId")
+  List<Long> findJobIdsByUserId(@Param("userId") Long userId);
+
+  Optional<SavedJob> findByUserIdAndJobId(Long userId, Long jobId);
+
+  boolean existsByUserIdAndJobId(Long userId, Long jobId);
+
+  void deleteByUserIdAndJobId(Long userId, Long jobId);
+}

--- a/src/main/java/com/skywins/Job/Application/savedjob/SavedJobService.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/SavedJobService.java
@@ -1,0 +1,13 @@
+package com.skywins.Job.Application.savedjob;
+
+import java.util.List;
+
+public interface SavedJobService {
+  List<SavedJob> findSavedJobsByUser(Long userId);
+
+  List<Long> findSavedJobIdsByUser(Long userId);
+
+  boolean saveJob(Long userId, Long jobId);
+
+  boolean deleteSavedJob(Long userId, Long jobId);
+}

--- a/src/main/java/com/skywins/Job/Application/savedjob/dto/SavedJobResponse.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/dto/SavedJobResponse.java
@@ -1,0 +1,57 @@
+package com.skywins.Job.Application.savedjob.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.skywins.Job.Application.company.dto.CompanySummaryResponse;
+import com.skywins.Job.Application.job.dto.ExperienceResponse;
+import com.skywins.Job.Application.job.dto.JobResponse;
+import com.skywins.Job.Application.job.dto.SalaryResponse;
+import com.skywins.Job.Application.savedjob.SavedJob;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SavedJobResponse {
+  private Long id;
+  private String title;
+  private String description;
+  private String minSalary;
+  private String maxSalary;
+  private String location;
+  private String jobType;
+  private String employmentType;
+  private ExperienceResponse experience;
+  private List<String> skills;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+  private LocalDateTime postedAt;
+
+  private boolean isNew;
+  private SalaryResponse salary;
+  private CompanySummaryResponse company;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+  private LocalDateTime savedAt;
+
+  public static SavedJobResponse from(SavedJob savedJob) {
+    JobResponse job = JobResponse.from(savedJob.getJob());
+    return new SavedJobResponse(
+        job.getId(),
+        job.getTitle(),
+        job.getDescription(),
+        job.getMinSalary(),
+        job.getMaxSalary(),
+        job.getLocation(),
+        job.getJobType(),
+        job.getEmploymentType(),
+        job.getExperience(),
+        job.getSkills(),
+        job.getPostedAt(),
+        job.isNew(),
+        job.getSalary(),
+        job.getCompany(),
+        savedJob.getCreatedAt());
+  }
+}

--- a/src/main/java/com/skywins/Job/Application/savedjob/dto/SavedJobStatusResponse.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/dto/SavedJobStatusResponse.java
@@ -1,0 +1,11 @@
+package com.skywins.Job.Application.savedjob.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SavedJobStatusResponse {
+  private Long jobId;
+  private boolean saved;
+}

--- a/src/main/java/com/skywins/Job/Application/savedjob/impl/SavedJobServiceimpl.java
+++ b/src/main/java/com/skywins/Job/Application/savedjob/impl/SavedJobServiceimpl.java
@@ -1,0 +1,67 @@
+package com.skywins.Job.Application.savedjob.impl;
+
+import com.skywins.Job.Application.job.Job;
+import com.skywins.Job.Application.job.JobRepository;
+import com.skywins.Job.Application.savedjob.SavedJob;
+import com.skywins.Job.Application.savedjob.SavedJobRepository;
+import com.skywins.Job.Application.savedjob.SavedJobService;
+import com.skywins.Job.Application.user.User;
+import com.skywins.Job.Application.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SavedJobServiceimpl implements SavedJobService {
+  private final SavedJobRepository savedJobRepository;
+  private final JobRepository jobRepository;
+  private final UserRepository userRepository;
+
+  public SavedJobServiceimpl(
+      SavedJobRepository savedJobRepository,
+      JobRepository jobRepository,
+      UserRepository userRepository) {
+    this.savedJobRepository = savedJobRepository;
+    this.jobRepository = jobRepository;
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public List<SavedJob> findSavedJobsByUser(Long userId) {
+    return savedJobRepository.findByUserIdOrderByCreatedAtDesc(userId);
+  }
+
+  @Override
+  public List<Long> findSavedJobIdsByUser(Long userId) {
+    return savedJobRepository.findJobIdsByUserId(userId);
+  }
+
+  @Override
+  @Transactional
+  public boolean saveJob(Long userId, Long jobId) {
+    if (savedJobRepository.existsByUserIdAndJobId(userId, jobId)) {
+      return true;
+    }
+
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException("User not found"));
+    Job job =
+        jobRepository
+            .findById(jobId)
+            .orElseThrow(() -> new EntityNotFoundException("Job not found"));
+
+    SavedJob savedJob = SavedJob.builder().user(user).job(job).build();
+    savedJobRepository.save(savedJob);
+    return true;
+  }
+
+  @Override
+  @Transactional
+  public boolean deleteSavedJob(Long userId, Long jobId) {
+    savedJobRepository.deleteByUserIdAndJobId(userId, jobId);
+    return false;
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce a persistent "saved jobs" feature so users can save and list jobs they are interested in. 
- Provide API endpoints to fetch saved jobs, fetch saved job ids, save a job, and delete a saved job. 
- Support mapping between domain entities and API responses with DTOs for consistent output shapes.

### Description
- Add the `SavedJob` JPA entity with a unique constraint on `user_id`+`job_id`, `createdAt` timestamp, and a `@PrePersist` initializer. 
- Add `SavedJobRepository` with queries `findByUserIdOrderByCreatedAtDesc`, `findJobIdsByUserId`, `findByUserIdAndJobId`, `existsByUserIdAndJobId`, and `deleteByUserIdAndJobId`. 
- Add service interface `SavedJobService` and implementation `SavedJobServiceimpl` that provide `findSavedJobsByUser`, `findSavedJobIdsByUser`, `saveJob` (idempotent), and `deleteSavedJob` (performs deletion). 
- Add `SavedJobController` exposing `GET /api/saved-jobs`, `GET /api/saved-jobs/ids`, `POST /api/saved-jobs/{jobId}`, and `DELETE /api/saved-jobs/{jobId}` and returning `ApiResponse` wrappers. 
- Add DTOs `SavedJobResponse` and `SavedJobStatusResponse` and mapping logic to convert `SavedJob`/`Job` entities into API response shapes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a849f1bc338832ab4fb31f0dcc2ebb5)